### PR TITLE
fix(windows): link using "system" ABI

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -121,8 +121,7 @@ mod ffi {
     /// Null-terminated UTF-16 encoding of `open`.  
     pub const OPEN: *const u16 = [111, 112, 101, 110, 0].as_ptr();
 
-    #[link(name = "Shell32")]
-    extern "C" {
+    extern "system" {
         pub fn ShellExecuteW(
             hwnd: isize,
             lpoperation: *const u16,
@@ -130,6 +129,6 @@ mod ffi {
             lpparameters: *const u16,
             lpdirectory: *const u16,
             nshowcmd: i32,
-        ) -> i32;
+        ) -> isize;
     }
 }


### PR DESCRIPTION
Finally was able to reproduce https://github.com/Byron/open-rs/pull/91#issuecomment-1974905927
through https://github.com/tauri-apps/plugins-workspace/issues/1046

This was a mistake on my part in #91, I didn't notice that I used the wrong ABI, funnily enough I can still build on x86 & x64 targets using the wrong ABI.